### PR TITLE
remove net45 target

### DIFF
--- a/build/Version.props
+++ b/build/Version.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <Version>7.0.1</Version>
+    <Version>7.1.0</Version>
   </PropertyGroup>
 </Project>

--- a/samples/Walterlv.Windows.Sample/Walterlv.Windows.Sample.csproj
+++ b/samples/Walterlv.Windows.Sample/Walterlv.Windows.Sample.csproj
@@ -7,8 +7,12 @@
     <ApplicationManifest>Properties\App.manifest</ApplicationManifest>
   </PropertyGroup>
 
+	<ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
+	</ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Include="..\..\src\Diagnostics\Walterlv.NullableAttributes\Walterlv.NullableAttributes.csproj" />
+    <ProjectReference Include="..\..\src\Analyzers\Walterlv.NullableAttributes\Walterlv.NullableAttributes.csproj" />
     <ProjectReference Include="..\..\src\Frameworks\Walterlv.Windows.Framework\Walterlv.Windows.Framework.Wpf\Walterlv.Windows.Framework.Wpf.csproj" />
     <ProjectReference Include="..\..\src\Themes\Walterlv.Themes.FluentDesign\Walterlv.Themes.FluentDesign.csproj" />
     <ProjectReference Include="..\..\src\Utils\Walterlv.Collections\Walterlv.Collections.csproj" />

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -24,7 +24,8 @@
     <PackageProjectUrl>https://github.com/walterlv/Walterlv.Packages</PackageProjectUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="dotnetCampus.SourceYard" Version="0.1.19371-alpha" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="dotnetCampus.SourceYard" Version="0.1.19371-alpha" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="all"/>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/Utils/Walterlv.Logger/IO/TextFileLogger.cs
+++ b/src/Utils/Walterlv.Logger/IO/TextFileLogger.cs
@@ -318,9 +318,16 @@ namespace Walterlv.Logging.IO
                 }
                 catch (IOException ex)
                 {
+                    const int HR_ERROR_PATH_NOT_FOUND = unchecked((int)0x80070003);
                     const int HR_ERROR_HANDLE_DISK_FULL = unchecked((int)0x80070027);
                     const int HR_ERROR_DISK_FULL = unchecked((int)0x80070070);
-                    if (ex.HResult == HR_ERROR_HANDLE_DISK_FULL || ex.HResult == HR_ERROR_DISK_FULL)
+                    if (ex.HResult == HR_ERROR_PATH_NOT_FOUND)
+                    {
+                        // 路径不存在。
+                        Directory.CreateDirectory(Path.GetDirectoryName(fileName));
+                        await Task.Delay(10).ConfigureAwait(false);
+                    }
+                    else if (ex.HResult == HR_ERROR_HANDLE_DISK_FULL || ex.HResult == HR_ERROR_DISK_FULL)
                     {
                         // 磁盘已满，不再写入。
                         return;

--- a/tests/Walterlv.Packages.Performance/Walterlv.Packages.Performance.csproj
+++ b/tests/Walterlv.Packages.Performance/Walterlv.Packages.Performance.csproj
@@ -9,7 +9,8 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.0" />
-  </ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
+	</ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Utils\Walterlv.Collections\Walterlv.Collections.csproj" />

--- a/tests/Walterlv.Packages.Tests/Walterlv.Packages.Tests.csproj
+++ b/tests/Walterlv.Packages.Tests/Walterlv.Packages.Tests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.10.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.4" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.4" />


### PR DESCRIPTION
[无需安装 VS2019，在 Visual Studio 2022 中编译 .NET Framework 4.5/4/3.5 这样的古老框架 - walterlv](http://blog.walterlv.com/post/support-old-netfx-on-vs2022-or-later.html)